### PR TITLE
using contour dropdown value as key in json response

### DIFF
--- a/biomarkerTools/sampleSize/sampleSize.js
+++ b/biomarkerTools/sampleSize/sampleSize.js
@@ -144,8 +144,13 @@ thisTool.find("#minInput, #maxInput").on('change', function() {
         compareVal = thisTool.find("#minInput").val();
     }
 
-    if((thisVal.length + compareVal.length >= 2) && thisVal == compareVal) {
-        display_errors("Min Value and Max Value of k cannot be equal");
+    if(thisVal.length + compareVal.length >= 2) {
+        if(thisVal == compareVal) {
+            display_errors("Min Value and Max Value of k cannot be equal");
+        }
+        else if( thisTool.find("#maxInput").val() < thisTool.find("#minInput").val()) {
+            display_errors("Max Value cannot be less than the Min Value");
+        }
     }
     else {
         thisTool.find("#errors").empty().addClass("hide");
@@ -155,6 +160,7 @@ thisTool.find("#minInput, #maxInput").on('change', function() {
 thisTool.find("#contour_dropdown").on("change", lock_fixed_options);
 
 function generate_tables(jsonrtn){
+    
     for(var i in jsonrtn) {
        
         var tablesvar = "<TABLE class='table table-bordered table-condensed small'><TBODY>";

--- a/biomarkerTools/src/app/scripts/sampleSize/sampleSize.js
+++ b/biomarkerTools/src/app/scripts/sampleSize/sampleSize.js
@@ -144,8 +144,13 @@ thisTool.find("#minInput, #maxInput").on('change', function() {
         compareVal = thisTool.find("#minInput").val();
     }
 
-    if((thisVal.length + compareVal.length >= 2) && thisVal == compareVal) {
-        display_errors("Min Value and Max Value of k cannot be equal");
+    if(thisVal.length + compareVal.length >= 2) {
+        if(thisVal == compareVal) {
+            display_errors("Min Value and Max Value of k cannot be equal");
+        }
+        else if( thisTool.find("#maxInput").val() < thisTool.find("#minInput").val()) {
+            display_errors("Max Value cannot be less than the Min Value");
+        }
     }
     else {
         thisTool.find("#errors").empty().addClass("hide");
@@ -155,19 +160,22 @@ thisTool.find("#minInput, #maxInput").on('change', function() {
 thisTool.find("#contour_dropdown").on("change", lock_fixed_options);
 
 function generate_tables(jsonrtn){
+    // use this value as a key in the json data
+    var label = $(contour_dropdown.selectedOptions).text();
+    
     for(var i in jsonrtn) {
         //        console.log(i);
         var tablesvar = "<TABLE class='table table-bordered table-condensed small'><TBODY>";
-        tablesvar += "<TR><TH class='table_data header'>Sensitivity</TH><TH class='table_data header'>Optimal k</TH><TH class='table_data header'>Relative efficiency gain or <br>loss compared to k = 0.5</TH></TR>";
+        tablesvar += "<TR><TH class='table_data header'>" + label + "</TH><TH class='table_data header'>Optimal k</TH><TH class='table_data header'>Relative efficiency gain or <br>loss compared to k = 0.5</TH></TR>";
         var ppvtabledata = tablesvar;
         var cnpvtabledata = tablesvar;
         for(var n=0; n<jsonrtn[i].PPVData.length; n++) {
             //            console.log("PPVData");
-            ppvtabledata += "<TR><TD>"+jsonrtn[i].PPVData[n].Sensitivity+"</TD>";
+            ppvtabledata += "<TR><TD>" + jsonrtn[i].PPVData[n][label] + "</TD>";
             ppvtabledata += "<TD>"+jsonrtn[i].PPVData[n]["Optimal k"]+"</TD>";
             ppvtabledata += "<TD>"+jsonrtn[i].PPVData[n]['Relative efficiency gain or loss compared to k = 0.5']+"</TD>";
-            //            console.log("cNPVData");
-            cnpvtabledata += "<TD>"+jsonrtn[i].cNPVData[n].Sensitivity+"</TD>";
+
+            cnpvtabledata += "<TD>" + jsonrtn[i].cNPVData[n][label] + "</TD>";
             cnpvtabledata += "<TD>"+jsonrtn[i].cNPVData[n]["Optimal k"]+"</TD>";
             cnpvtabledata += "<TD>"+jsonrtn[i].cNPVData[n]['Relative efficiency gain or loss compared to k = 0.5']+"</TD></TR>";
         }


### PR DESCRIPTION
In the original code, Sensitivity was hard coded no matter the value of contour. This is now changed by using the contour drop down value as a key to find the value within the returned json.

Also improved validation checks in sample size. The min and max values cannot be equal and max cannot be greater than min.